### PR TITLE
adding-write-velocity-or-displacement-history-option

### DIFF
--- a/EzGM/selection.py
+++ b/EzGM/selection.py
@@ -263,9 +263,9 @@ class _subclass_:
             The default is 1.
         rtype : str, optional
             option to choose the type of time history to be written.
-            'acc' : for the acceleration series
-            'vel' : for the velocity series
-            'disp': for the displacement series
+            'acc' : for the acceleration series, units: g
+            'vel' : for the velocity series, units: g * sec
+            'disp': for the displacement series: units: g * sec2
         recs_f : str, optional
             This is option could be used if the user already has all the
             records in database. This is the folder path which contains
@@ -281,7 +281,7 @@ class _subclass_:
         -------
         None.
         """
-        def save_signal(path, acc, sf, dt):
+        def save_signal(path, uns_acc, sf, dt):
             """
             Details
             -------
@@ -320,6 +320,8 @@ class _subclass_:
                 zipName = self.Unscaled_rec_file
             except AttributeError:
                 zipName = os.path.join(recs_f, self.database['Name'] + '.zip')
+            path_sf = os.path.join(self.outdir, 'GMR_sf_used')
+            np.savetxt(path_sf, np.array([self.rec_scale]).T, fmt='%1.5f')
             n = len(self.rec_h1)
             path_dts = os.path.join(self.outdir, 'GMR_dts.txt')
             dts = np.zeros(n)
@@ -376,11 +378,11 @@ class _subclass_:
                     inp_acc2 = temp2.copy()
 
                     # H2 component
-                    save_signal(path=os.path.join(self.outdir, gmr_file2), inp_acc2, self.rec_scale[i], dts[i])
+                    save_signal(os.path.join(self.outdir, gmr_file2), inp_acc2, self.rec_scale[i], dts[i])
                     h2s.write(gmr_file2 + '\n')
 
                 # H1 component
-                save_signal(path=os.path.join(self.outdir, gmr_file1), inp_acc1, self.rec_scale[i], dts[i])
+                save_signal(os.path.join(self.outdir, gmr_file1), inp_acc1, self.rec_scale[i], dts[i])
                 h1s.write(gmr_file1 + '\n')
 
             # Time steps

--- a/EzGM/selection.py
+++ b/EzGM/selection.py
@@ -320,10 +320,7 @@ class _subclass_:
                 zipName = self.Unscaled_rec_file
             except AttributeError:
                 zipName = os.path.join(recs_f, self.database['Name'] + '.zip')
-            path_sf = os.path.join(self.outdir, 'GMR_sf_used')
-            np.savetxt(path_sf, np.array([self.rec_scale]).T, fmt='%1.5f')
             n = len(self.rec_h1)
-            path_dts = os.path.join(self.outdir, 'GMR_dts.txt')
             dts = np.zeros(n)
             path_H1 = os.path.join(self.outdir, 'GMR_names.txt')
             if self.selection == 2:
@@ -386,14 +383,16 @@ class _subclass_:
                 h1s.write(gmr_file1 + '\n')
 
             # Time steps
-            np.savetxt(path_dts, dts, fmt='%.5f')
+            np.savetxt(os.path.join(self.outdir, 'GMR_dts.txt'), dts, fmt='%.5f')
+            # Scale factors
+            np.savetxt(os.path.join(self.outdir, 'GMR_sf_used'), np.array([self.rec_scale]).T, fmt='%1.5f')
+            # Close the files
             h1s.close()
             if self.selection == 2:
                 h2s.close()
 
         if obj == 1:
             # save some info as pickle obj
-            path_obj = os.path.join(self.outdir, 'obj.pkl')
             obj = vars(copy.deepcopy(self))  # use copy.deepcopy to create independent obj
             obj['database'] = self.database['Name']
             del obj['outdir']
@@ -401,7 +400,7 @@ class _subclass_:
             if 'bgmpe' in obj:
                 del obj['bgmpe']
 
-            with open(path_obj, 'wb') as file:
+            with open(os.path.join(self.outdir, 'obj.pkl'), 'wb') as file:
                 pickle.dump(obj, file)
 
         print(f"Finished writing process, the files are located in\n{self.outdir}")

--- a/EzGM/selection.py
+++ b/EzGM/selection.py
@@ -281,6 +281,36 @@ class _subclass_:
         -------
         None.
         """
+        def rename_nga(filename, hist):
+            # modify the NGA acceleration file name (acceleration, velocity or displacement)
+            # filename  : string, file name for the acceleration history
+            # hist      : string, type of time history
+            if hist == 'vel':
+                new_name = filename.replace('.txt', '_VEL.txt')
+
+            elif hist == 'disp':
+                new_name = filename.replace('.txt', '_DISP.txt')
+
+            else:
+                new_name = filename
+
+            return new_name
+
+        def rename_esm(filename, hist):
+            # modify the ESM acceleration file name (acceleration, velocity or displacement)
+            # filename  : string, file name for the acceleration history
+            # hist      : string, type of time history
+            if hist == 'vel':
+                new_name = filename.replace('ACC', 'VEL')
+
+            elif hist == 'disp':
+                new_name = filename.replace('ACC', 'DISP')
+
+            else:
+                new_name = filename
+
+            return new_name
+
         def get_history(acc_history, dt, hist):
             # return the desired time history vector (acceleration, velocity or displacement)
             # acc_history   : numpy vector
@@ -336,17 +366,21 @@ class _subclass_:
                     dts[i], npts1, _, _, inp_acc1 = ReadNGA(inFilename=self.rec_h1[i], content=contents1[i])
                     gmr_file1 = self.rec_h1[i].replace('/', '_')[:-4] + '_SF_' + "{:.3f}".format(
                         self.rec_scale[i]) + '.txt'
+                    gmr_file1 = rename_nga(gmr_file1, rtype)
                     if self.selection == 2:  # H2 component
                         _, npts2, _, _, inp_acc2 = ReadNGA(inFilename=self.rec_h2[i], content=contents2[i])
                         gmr_file2 = self.rec_h2[i].replace('/', '_')[:-4] + '_SF_' + "{:.3f}".format(
                             self.rec_scale[i]) + '.txt'
+                        gmr_file2 = rename_nga(gmr_file2, rtype)
 
                 elif self.database['Name'].startswith('ESM'):  # ESM
                     dts[i], npts1, _, _, inp_acc1 = ReadESM(inFilename=self.rec_h1[i], content=contents1[i])
                     gmr_file1 = self.rec_h1[i][:-4] + '_SF_' + "{:.3f}".format(self.rec_scale[i]) + '.txt'
+                    gmr_file1 = rename_esm(gmr_file1, rtype)
                     if self.selection == 2:  # H2 component
                         _, npts2, _, _, inp_acc2 = ReadESM(inFilename=self.rec_h2[i], content=contents2[i])
                         gmr_file2 = self.rec_h2[i][:-4] + '_SF_' + "{:.3f}".format(self.rec_scale[i]) + '.txt'
+                        gmr_file2 = rename_esm(gmr_file2, rtype)
 
                 # Write the record files
                 if self.selection == 2:


### PR DESCRIPTION
@volkanozsarac

Modify the write method of EzGM.selection:

1) add rtype option
2) write documentation for rtype
3) implement get_history() local method
4) integrate acc. series dir. 1 and 2 just after scaling and before writing to txt

**_get_history(series, dt, type)_:** Cumulatively integrates "series" over [0, t] with "dt" to obtain "type".

**Comparison between EzGM and SeismoSignal:**

![EzGM vs SeismoSignal](https://user-images.githubusercontent.com/44577285/199540363-563f04ec-4bb9-4a8c-8abd-477869d4a631.png)

